### PR TITLE
Added libusb dependency

### DIFF
--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -11,6 +11,7 @@ class EpsilonSdk < Formula
   depends_on "libpng"
   depends_on "pkg-config"
   depends_on "python"
+  depends_on "libusb"
 
   def install
     bin.mkpath


### PR DESCRIPTION
This pull request adds libusb as a dependency on macOS, as libusb seems to be needed to run PyUSB and execute the epsilon_flash scheme on macOS (Otherwise, a usb.core.NoBackendError is raised).