### PR TITLE
Fix Python and his dependencies

### DIFF
--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -19,8 +19,8 @@ class EpsilonSdk < Formula
   end
 
   resource "pypng" do
-    url "https://github.com/drj11/pypng/archive/refs/tags/pypng-0.0.21.tar.gz"
-    sha256 "0c9285db09c8e3b66f884a0448dc2ae78737e228f69bfe9dfde1faa1d4f1c945"
+    url "https://github.com/drj11/pypng/archive/refs/tags/pypng-0.0.20.tar.gz"
+    sha256 "d008a1f1f79633937ed2aa1742c7c077359edce53764b8b247891056ddca913c"
   end
 
   resource "stringcase" do

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -30,14 +30,12 @@ class EpsilonSdk < Formula
   end
 
   def install
-    # Install dependencies first
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python3.8/site-packages"
     %w[lz4 pypng stringcase].each do |r|
       resource(r).stage do
         system "python3", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
-    # virtualenv_install_with_resources
     bin.mkpath
   end
 

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -11,7 +11,7 @@ class EpsilonSdk < Formula
   depends_on "imagemagick"
   depends_on "libpng"
   depends_on "pkg-config"
-  depends_on "python"
+  depends_on "python@3.8"
   depends_on "libusb"
 
   resource "lz4" do
@@ -20,8 +20,8 @@ class EpsilonSdk < Formula
   end
 
   resource "pypng" do
-    url "https://files.pythonhosted.org/packages/ac/56/8b9d4ba9290bb6bd0b0824fd6f4ce8a852126f203f3edcef8b7abfbd8937/pypng-0.0.21-py3-none-any.whl"
-    sha256 "76f8a1539ec56451da7ab7121f12a361969fe0f2d48d703d198ce2a99d6c5afd"
+    url "https://github.com/drj11/pypng/archive/refs/tags/pypng-0.0.20.tar.gz"
+    sha256 "d008a1f1f79633937ed2aa1742c7c077359edce53764b8b247891056ddca913c"
   end
 
   resource "stringcase" do

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -30,7 +30,14 @@ class EpsilonSdk < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    # Install dependencies first
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python3.8/site-packages"
+    %w[lz4 pypng stringcase].each do |r|
+      resource(r).stage do
+        system "python3", *Language::Python.setup_install_args(libexec/"vendor")
+      end
+    end
+    # virtualenv_install_with_resources
     bin.mkpath
   end
 

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -1,5 +1,4 @@
 class EpsilonSdk < Formula
-  include Language::Python::Virtualenv
   desc "Epsilon SDK"
   homepage "https://www.numworks.com/resources/engineering/software/"
   url "file:///dev/null"

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -10,7 +10,7 @@ class EpsilonSdk < Formula
   depends_on "imagemagick"
   depends_on "libpng"
   depends_on "pkg-config"
-  depends_on "python@3.x"
+  depends_on "python@3.8"
   depends_on "libusb"
 
   resource "lz4" do

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -20,7 +20,7 @@ class EpsilonSdk < Formula
 
   resource "pypng" do
     url "https://github.com/drj11/pypng/archive/refs/tags/pypng-0.0.21.tar.gz"
-    sha256 "d008a1f1f79633937ed2aa1742c7c077359edce53764b8b247891056ddca913c"
+    sha256 "0c9285db09c8e3b66f884a0448dc2ae78737e228f69bfe9dfde1faa1d4f1c945"
   end
 
   resource "stringcase" do

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -19,7 +19,7 @@ class EpsilonSdk < Formula
   end
 
   resource "pypng" do
-    url "https://github.com/drj11/pypng/archive/refs/tags/pypng-0.0.20.tar.gz"
+    url "https://github.com/drj11/pypng/archive/refs/tags/pypng-0.0.21.tar.gz"
     sha256 "d008a1f1f79633937ed2aa1742c7c077359edce53764b8b247891056ddca913c"
   end
 

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -1,4 +1,5 @@
 class EpsilonSdk < Formula
+  include Language::Python::Virtualenv
   desc "Epsilon SDK"
   homepage "https://www.numworks.com/resources/engineering/software/"
   url "file:///dev/null"
@@ -29,7 +30,6 @@ class EpsilonSdk < Formula
   end
 
   def install
-    virtualenv_create(libexec, "python3")
     virtualenv_install_with_resources
     bin.mkpath
   end

--- a/epsilon-sdk.rb
+++ b/epsilon-sdk.rb
@@ -10,7 +10,7 @@ class EpsilonSdk < Formula
   depends_on "imagemagick"
   depends_on "libpng"
   depends_on "pkg-config"
-  depends_on "python@3.8"
+  depends_on "python"
   depends_on "libusb"
 
   resource "lz4" do
@@ -29,6 +29,7 @@ class EpsilonSdk < Formula
   end
 
   def install
+    virtualenv_create(libexec, "python3")
     virtualenv_install_with_resources
     bin.mkpath
   end


### PR DESCRIPTION
Fixes Python 3.x installation by restoring Python 3.8, change PyPng URL to the tarball because it cannot extract the `.whl` file and install manually the dependencies, because it wants to install `epsilon-sdk` as a Python package. Fixes #3. You can see the working installation [here](https://github.com/Yaya-Cout/Upsilon/runs/7184402588?check_suite_focus=true).